### PR TITLE
Bump pluginVersion to 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-07-19
+
 ### Changed
 
 - Sync scaffolding with the IntelliJ Platform Plugin Template `2.6.0` base (was `2.0.2`):

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.hiosdra.commitmessagecleanerplugin
 pluginName = CommitMessageCleaner
 pluginRepositoryUrl = https://github.com/Hiosdra/CommitMessageCleanerPlugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.4
+pluginVersion = 0.2.5
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243


### PR DESCRIPTION
## Summary

The GitHub release [`0.2.5`](https://github.com/Hiosdra/CommitMessageCleanerPlugin/releases/tag/0.2.5) was published while `gradle.properties` still had `pluginVersion = 0.2.4`, which the JetBrains Marketplace already has a build for. `release.yml`'s `publishPlugin` step [failed](https://github.com/Hiosdra/CommitMessageCleanerPlugin/actions/runs/29705129699/job/88241267883):

```
Failed to upload plugin: Upload failed: The com.hiosdra.commitmessagecleanerplugin plugin already contains version 0.2.4 in channel
```

- Bump `pluginVersion` to `0.2.5` in `gradle.properties`
- Move the `Unreleased` changelog entries under a `## [0.2.5]` heading in `CHANGELOG.md`

## Test plan

- [ ] After merging, recreate the `0.2.5` release (delete + republish, or delete/retag) so it points at a commit with the bumped version, then confirm `release.yml`'s `publishPlugin` step succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01TErc9urkZA2BNL3hxQ9Btw)_