### PR TITLE
Configurable formatting, Conventional Commits & commit-flow integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Settings panel** (`Settings/Preferences | Tools | Commit Message Cleaner`) to configure the
+  separator, message capitalization and the ticket-detection regex, so the plugin fits conventions
+  beyond the built-in Jira-style `PREFIX-123 | Message`.
+- **Conventional Commits** format style (`feat(ABC-123): message`) with type detection and the
+  branch ticket used as scope.
+- **Clean on commit**: an opt-in `CheckinHandler` that cleans the commit message automatically right
+  before the commit is created.
+- **Optional before/after preview** balloon after a manual clean.
+- **Keyboard shortcuts** (`Ctrl+Alt+K` / `Ctrl+Alt+Shift+K`) and entries in the `Git` menu for both
+  actions.
+
+### Changed
+
+- **Multi-repository / monorepo support**: `Get Ticket From Branch And Clean` now resolves the Git
+  repository from the files included in the commit instead of always using the first one.
+- Cleaning of an unchanged message is now a no-op (no spurious document modification), and the
+  whole-text replacement stays a single Undo step.
+
 ## [0.2.5] - 2026-07-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@
   <br />
   The <code>Get Ticket From Branch And Clean</code> action uses the current Git branch name to extract a ticket identifier and applies it to the commit message.
 </p>
+<p>Both actions are configurable under <code>Settings/Preferences | Tools | Commit Message Cleaner</code>:</p>
+<ul>
+  <li><b>Format style</b> — the classic <code>ABC-123 | Message</code> ticket-prefix style, or <b>Conventional Commits</b> (<code>feat(ABC-123): message</code>).</li>
+  <li><b>Separator</b> and <b>capitalization</b> of the message.</li>
+  <li><b>Ticket regex</b> so teams that don't use Jira-style ids are supported too.</li>
+  <li><b>Clean on commit</b> — clean the message automatically right before committing, so it never gets forgotten.</li>
+  <li><b>Preview notification</b> — an optional before/after balloon after each clean.</li>
+</ul>
+<p>
+  In multi-repository (monorepo) projects the ticket is taken from the repository that owns the files
+  being committed, and both actions are also available via keyboard shortcuts and the <code>Git</code> menu.
+</p>
 <!-- Plugin description end -->
 
 ## Installation

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanCommitMessageAction.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanCommitMessageAction.kt
@@ -2,21 +2,19 @@
 
 package com.hiosdra.commitmessagecleanerplugin
 
+import com.hiosdra.commitmessagecleanerplugin.settings.CleanerSettingsState
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.vcs.VcsDataKeys
 
 class CleanCommitMessageAction : AnAction() {
     override fun actionPerformed(event: AnActionEvent) {
-        val checkinPanel = event.getData(VcsDataKeys.COMMIT_MESSAGE_DOCUMENT) ?: return
+        val document = event.getData(VcsDataKeys.COMMIT_MESSAGE_DOCUMENT) ?: return
 
-        val commitMessage = checkinPanel.text
-        val updatedMessage = CommitMessageCleaner.cleanWithTicketNumber(commitMessage)
-        WriteAction.runAndWait<Throwable> {
-            checkinPanel.setText(updatedMessage)
-        }
+        val settings = CleanerSettingsState.current()
+        val updatedMessage = CommitMessageCleaner.cleanWithTicketNumber(document.text, settings)
+        CommitMessageUpdater.apply(document, updatedMessage, settings)
     }
 
     override fun getActionUpdateThread(): ActionUpdateThread {

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanOnCommitHandler.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanOnCommitHandler.kt
@@ -1,0 +1,40 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.hiosdra.commitmessagecleanerplugin
+
+import com.hiosdra.commitmessagecleanerplugin.settings.CleanerSettings
+import com.hiosdra.commitmessagecleanerplugin.settings.CleanerSettingsState
+import com.intellij.openapi.vcs.CheckinProjectPanel
+import com.intellij.openapi.vcs.checkin.CheckinHandler
+
+/**
+ * Cleans the commit message automatically, right before the commit is created, when the user has
+ * enabled "clean on commit" in the settings. This removes the reliance on remembering to press the
+ * action button, so history stays consistent without any manual step.
+ */
+class CleanOnCommitHandler(private val panel: CheckinProjectPanel) : CheckinHandler() {
+
+    override fun beforeCheckin(): ReturnResult {
+        val settings = CleanerSettingsState.current()
+        if (!settings.autoCleanOnCommit) return ReturnResult.COMMIT
+
+        val original = panel.commitMessage
+        val cleaned = clean(settings, original)
+        if (cleaned != original) {
+            panel.setCommitMessage(cleaned)
+        }
+        return ReturnResult.COMMIT
+    }
+
+    private fun clean(settings: CleanerSettings, message: String): String {
+        val branchName = RepositorySelector.select(panel.project, panel.selectedChanges)
+            ?.currentBranch
+            ?.name
+
+        return if (branchName != null) {
+            CommitMessageCleaner.cleanWithTicketFromBranch(branchName, message, settings)
+        } else {
+            CommitMessageCleaner.cleanWithTicketNumber(message, settings)
+        }
+    }
+}

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanOnCommitHandler.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanOnCommitHandler.kt
@@ -21,7 +21,7 @@ class CleanOnCommitHandler(private val panel: CheckinProjectPanel) : CheckinHand
         val original = panel.commitMessage
         val cleaned = clean(settings, original)
         if (cleaned != original) {
-            panel.setCommitMessage(cleaned)
+            panel.commitMessage = cleaned
         }
         return ReturnResult.COMMIT
     }

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanOnCommitHandlerFactory.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanOnCommitHandlerFactory.kt
@@ -1,0 +1,14 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.hiosdra.commitmessagecleanerplugin
+
+import com.intellij.openapi.vcs.CheckinProjectPanel
+import com.intellij.openapi.vcs.changes.CommitContext
+import com.intellij.openapi.vcs.checkin.CheckinHandler
+import com.intellij.openapi.vcs.checkin.CheckinHandlerFactory
+
+/** Registers [CleanOnCommitHandler] with the VCS commit workflow. */
+class CleanOnCommitHandlerFactory : CheckinHandlerFactory() {
+    override fun createHandler(panel: CheckinProjectPanel, commitContext: CommitContext): CheckinHandler =
+        CleanOnCommitHandler(panel)
+}

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanerNotifications.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanerNotifications.kt
@@ -1,0 +1,26 @@
+package com.hiosdra.commitmessagecleanerplugin
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
+
+/**
+ * Central place for the plugin's balloon notifications. The group id must match the
+ * `notificationGroup` declared in `plugin.xml`.
+ */
+object CleanerNotifications {
+
+    const val GROUP_ID = "Commit Message Cleaner"
+
+    fun warn(content: String) = notify(content, NotificationType.WARNING)
+
+    fun info(content: String) = notify(content, NotificationType.INFORMATION)
+
+    /** Shows a "before → after" preview of a cleaning operation. */
+    fun preview(before: String, after: String) =
+        info("Cleaned commit message:\n$before\n→\n$after")
+
+    private fun notify(content: String, type: NotificationType) {
+        Notifications.Bus.notify(Notification(GROUP_ID, content, type))
+    }
+}

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanerNotifications.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CleanerNotifications.kt
@@ -10,11 +10,11 @@ import com.intellij.notification.Notifications
  */
 object CleanerNotifications {
 
-    const val GROUP_ID = "Commit Message Cleaner"
+    private const val GROUP_ID = "Commit Message Cleaner"
 
     fun warn(content: String) = notify(content, NotificationType.WARNING)
 
-    fun info(content: String) = notify(content, NotificationType.INFORMATION)
+    private fun info(content: String) = notify(content, NotificationType.INFORMATION)
 
     /** Shows a "before → after" preview of a cleaning operation. */
     fun preview(before: String, after: String) =

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CommitMessageCleaner.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CommitMessageCleaner.kt
@@ -2,89 +2,186 @@
 
 package com.hiosdra.commitmessagecleanerplugin
 
+import com.hiosdra.commitmessagecleanerplugin.settings.CleanerSettings
+import com.hiosdra.commitmessagecleanerplugin.settings.FormatStyle
 import com.intellij.openapi.util.NlsSafe
 
+/**
+ * Formats commit messages. The behavior is driven by [CleanerSettings]; calling the methods without
+ * a settings argument uses [CleanerSettings.DEFAULT], which reproduces the plugin's original,
+ * hard-coded behavior exactly.
+ */
 object CommitMessageCleaner {
-    private val TICKET_PATTERN = "^([A-Za-z]+-\\d+)".toRegex()
-    private val FORMATTED_MESSAGE_PATTERN = "$TICKET_PATTERN \\| .+".toRegex()
-    private val TICKET_WITH_MESSAGE_PATTERN = "$TICKET_PATTERN \\| (.+)$".toRegex()
-    private val TICKET_SPACE_MESSAGE_PATTERN = "$TICKET_PATTERN\\s+(.+)$".toRegex()
 
-    fun cleanWithTicketNumber(commitMessage: @NlsSafe String): String {
-        if (commitMessage.isEmpty() || isAlreadyFormatted(commitMessage)) {
-            return commitMessage
+    private val defaultFormatter = Formatter(CleanerSettings.DEFAULT)
+
+    private fun formatterFor(settings: CleanerSettings): Formatter =
+        if (settings == CleanerSettings.DEFAULT) defaultFormatter else Formatter(settings)
+
+    fun cleanWithTicketNumber(
+        commitMessage: @NlsSafe String,
+        settings: CleanerSettings = CleanerSettings.DEFAULT,
+    ): String = formatterFor(settings).cleanWithTicketNumber(commitMessage)
+
+    fun getTicket(
+        branchName: @NlsSafe String,
+        settings: CleanerSettings = CleanerSettings.DEFAULT,
+    ): String? = formatterFor(settings).getTicket(branchName)
+
+    fun cleanWithTicketFromBranch(
+        branchName: @NlsSafe String,
+        commitMessage: @NlsSafe String,
+        settings: CleanerSettings = CleanerSettings.DEFAULT,
+    ): String = formatterFor(settings).cleanWithTicketFromBranch(branchName, commitMessage)
+
+    /**
+     * Stateless formatter bound to a single [CleanerSettings] snapshot. All the compiled patterns
+     * that depend on the configured separator or ticket regex are built once here.
+     */
+    private class Formatter(private val settings: CleanerSettings) {
+
+        private val escapedSeparator = Regex.escape(settings.separator)
+        private val ticketAnchored = "^(${settings.ticketRegex})"
+
+        private val formattedMessagePattern = Regex("$ticketAnchored $escapedSeparator .+")
+        private val ticketWithMessagePattern = Regex("$ticketAnchored $escapedSeparator (.+)$")
+        private val ticketSpaceMessagePattern = Regex("$ticketAnchored\\s+(.+)$")
+        private val conventionalPattern = Regex("^([A-Za-z]+)(\\(([^)]*)\\))?(!)?:\\s+(.*)$")
+
+        fun cleanWithTicketNumber(commitMessage: String): String = when (settings.formatStyle) {
+            FormatStyle.CONVENTIONAL_COMMITS -> cleanConventional(commitMessage, getTicket(commitMessage))
+            FormatStyle.TICKET_PREFIX -> cleanTicketPrefix(commitMessage)
         }
 
-        val parts = splitIntoParts(commitMessage)
-        if (parts.size < 3) return commitMessage
-
-        val ticketPrefix = parts[0]
-        val ticketNumber = parts[1]
-
-        return if (isValidTicketNumber(ticketNumber)) {
-            formatWithTicket("$ticketPrefix-$ticketNumber", extractMessageParts(parts, 2))
-        } else {
-            normalizeText(parts)
+        fun cleanWithTicketFromBranch(branchName: String, commitMessage: String): String {
+            val branchTicket = getTicket(branchName)
+            return when (settings.formatStyle) {
+                FormatStyle.CONVENTIONAL_COMMITS ->
+                    cleanConventional(commitMessage, branchTicket ?: getTicket(commitMessage))
+                FormatStyle.TICKET_PREFIX ->
+                    cleanTicketPrefixFromBranch(branchTicket, commitMessage)
+            }
         }
+
+        fun getTicket(branchName: String): String? {
+            val parts = splitIntoParts(branchName)
+            if (parts.size < 2) return null
+
+            val ticketPrefix = parts[0]
+            val ticketNumber = parts[1]
+
+            return if (isValidTicketNumber(ticketNumber)) "$ticketPrefix-$ticketNumber" else null
+        }
+
+        // --- TICKET_PREFIX style ------------------------------------------------------------
+
+        private fun cleanTicketPrefix(commitMessage: String): String {
+            if (commitMessage.isEmpty() || isAlreadyFormatted(commitMessage)) {
+                return commitMessage
+            }
+
+            val parts = splitIntoParts(commitMessage)
+            if (parts.size < 3) return commitMessage
+
+            val ticketPrefix = parts[0]
+            val ticketNumber = parts[1]
+
+            return if (isValidTicketNumber(ticketNumber)) {
+                formatWithTicket("$ticketPrefix-$ticketNumber", extractMessageParts(parts, 2))
+            } else {
+                normalizeText(parts)
+            }
+        }
+
+        private fun cleanTicketPrefixFromBranch(branchTicket: String?, commitMessage: String): String {
+            if (branchTicket == null) return cleanTicketPrefix(commitMessage)
+
+            val formattedMatch = ticketWithMessagePattern.find(commitMessage)
+            if (formattedMatch != null) {
+                val message = formattedMatch.groupValues.last()
+                return formatWithTicket(branchTicket, message)
+            }
+
+            val ticketPrefixMatch = ticketSpaceMessagePattern.find(commitMessage)
+            if (ticketPrefixMatch != null) {
+                val messageContent = ticketPrefixMatch.groupValues.last()
+                return formatWithTicket(branchTicket, messageContent)
+            }
+
+            val parts = splitIntoParts(commitMessage)
+            if (parts.size < 3 || !isValidTicketNumber(parts[1])) {
+                return formatWithTicket(branchTicket, commitMessage)
+            }
+
+            val messageWords = extractMessageParts(parts, 2)
+            return formatWithTicket(branchTicket, normalizeText(messageWords))
+        }
+
+        // --- CONVENTIONAL_COMMITS style ----------------------------------------------------
+
+        private fun cleanConventional(commitMessage: String, scopeTicket: String?): String {
+            val message = commitMessage.trim()
+
+            conventionalPattern.matchEntire(message)?.let { match ->
+                val type = match.groupValues[1]
+                val existingScope = match.groupValues[3]
+                val bang = match.groupValues[4]
+                val description = match.groupValues[5]
+                // Already conventional: only backfill an empty scope from the branch ticket.
+                return if (existingScope.isBlank() && !scopeTicket.isNullOrBlank()) {
+                    "$type($scopeTicket)$bang: $description"
+                } else {
+                    message
+                }
+            }
+
+            var body = message
+            val ownMatch = settings.ticketPattern.find(body)
+            if (ownMatch != null) {
+                body = body.substring(ownMatch.range.last + 1)
+            }
+            val scope = scopeTicket ?: ownMatch?.groupValues?.get(1)
+
+            val tokens = body.split('-', '_', ' ', '\t', '\n')
+                .filter { it.isNotBlank() }
+                .toMutableList()
+
+            var type = settings.conventionalDefaultType
+            if (tokens.isNotEmpty() && tokens.first().lowercase() in CleanerSettings.CONVENTIONAL_TYPES) {
+                type = tokens.removeAt(0).lowercase()
+            }
+
+            val description = tokens.joinToString(" ")
+            val header = if (scope.isNullOrBlank()) type else "$type($scope)"
+            return "$header: $description"
+        }
+
+        // --- shared helpers ----------------------------------------------------------------
+
+        private fun splitIntoParts(text: String): List<String> = text.split("-", "_")
+
+        private fun extractMessageParts(parts: List<String>, startIndex: Int): List<String> =
+            parts.subList(startIndex, parts.size)
+
+        private fun isAlreadyFormatted(message: String): Boolean =
+            formattedMessagePattern.matches(message)
+
+        private fun isValidTicketNumber(ticketNumber: String): Boolean =
+            ticketNumber.matches(Regex("^\\d+$"))
+
+        private fun normalizeText(words: List<String>): String {
+            val joined = words.joinToString(" ")
+            return if (settings.capitalizeFirstLetter) {
+                joined.replaceFirstChar { it.uppercase() }
+            } else {
+                joined
+            }
+        }
+
+        private fun formatWithTicket(ticket: String, message: String): String =
+            "$ticket ${settings.separator} $message"
+
+        private fun formatWithTicket(ticket: String, messageParts: List<String>): String =
+            formatWithTicket(ticket, normalizeText(messageParts))
     }
-
-    fun getTicket(branchName: @NlsSafe String): String? {
-        val parts = splitIntoParts(branchName)
-        if (parts.size < 2) return null
-
-        val ticketPrefix = parts[0]
-        val ticketNumber = parts[1]
-
-        return if (isValidTicketNumber(ticketNumber)) {
-            "$ticketPrefix-$ticketNumber"
-        } else {
-            null
-        }
-    }
-
-    fun cleanWithTicketFromBranch(branchName: @NlsSafe String, commitMessage: @NlsSafe String): String {
-        val branchTicket = getTicket(branchName) ?: return cleanWithTicketNumber(commitMessage)
-
-        val formattedMatch = TICKET_WITH_MESSAGE_PATTERN.find(commitMessage)
-        if (formattedMatch != null) {
-            val (_, message) = formattedMatch.destructured
-            return formatWithTicket(branchTicket, message)
-        }
-
-        val ticketPrefixMatch = TICKET_SPACE_MESSAGE_PATTERN.find(commitMessage)
-        if (ticketPrefixMatch != null) {
-            val (_, messageContent) = ticketPrefixMatch.destructured
-            return formatWithTicket(branchTicket, messageContent)
-        }
-
-        val parts = splitIntoParts(commitMessage)
-        if (parts.size < 3 || !isValidTicketNumber(parts[1])) {
-            return formatWithTicket(branchTicket, commitMessage)
-        }
-
-        val messageWords = extractMessageParts(parts, 2)
-        return formatWithTicket(branchTicket, normalizeText(messageWords))
-    }
-
-    private fun splitIntoParts(text: String): List<String> =
-        text.split("-", "_")
-
-    private fun extractMessageParts(parts: List<String>, startIndex: Int): List<String> =
-        parts.subList(startIndex, parts.size)
-
-    private fun isAlreadyFormatted(message: String): Boolean =
-        FORMATTED_MESSAGE_PATTERN.matches(message)
-
-    private fun isValidTicketNumber(ticketNumber: String): Boolean =
-        ticketNumber.matches("^\\d+$".toRegex())
-
-    private fun normalizeText(words: List<String>): String =
-        words.joinToString(" ")
-            .replaceFirstChar { it.uppercase() }
-
-    private fun formatWithTicket(ticket: String, message: String): String =
-        "$ticket | $message"
-
-    private fun formatWithTicket(ticket: String, messageParts: List<String>): String =
-        formatWithTicket(ticket, normalizeText(messageParts))
 }

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CommitMessageUpdater.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/CommitMessageUpdater.kt
@@ -1,0 +1,35 @@
+package com.hiosdra.commitmessagecleanerplugin
+
+import com.hiosdra.commitmessagecleanerplugin.settings.CleanerSettings
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.editor.Document
+
+/**
+ * Applies a cleaned message back onto the commit-message [Document].
+ *
+ * Replacing the whole document text in a single write is one undoable step in the commit field, so
+ * a stray clean can be reverted with a single Undo. When the text would not change we skip the
+ * write entirely (no spurious "modified" state, no empty undo step), and — when the user opted in —
+ * we surface a before/after preview.
+ */
+object CommitMessageUpdater {
+
+    /**
+     * @return `true` when the document text actually changed.
+     */
+    fun apply(document: Document, newText: String, settings: CleanerSettings): Boolean {
+        val before = document.text
+        if (before == newText) {
+            return false
+        }
+
+        WriteAction.runAndWait<Throwable> {
+            document.setText(newText)
+        }
+
+        if (settings.showPreviewNotification) {
+            CleanerNotifications.preview(before, newText)
+        }
+        return true
+    }
+}

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/GetFromBranchAndCleanAction.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/GetFromBranchAndCleanAction.kt
@@ -1,48 +1,40 @@
+@file:Suppress("UnstableApiUsage")
+
 package com.hiosdra.commitmessagecleanerplugin
 
-import com.intellij.notification.Notification
-import com.intellij.notification.NotificationType
-import com.intellij.notification.Notifications
+import com.hiosdra.commitmessagecleanerplugin.settings.CleanerSettingsState
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.vcs.VcsDataKeys
-import git4idea.GitUtil
 
 class GetFromBranchAndCleanAction : AnAction() {
     override fun actionPerformed(event: AnActionEvent) {
-        val repositories = GitUtil.getRepositories(event.project!!)
-        val repository = repositories.firstOrNull() ?: run {
-            showNotification("Currently you have no repository on this project. To get the branch name, you need to be on a repository.")
+        val project = event.project ?: return
+
+        val changes = event.getData(VcsDataKeys.CHANGES)?.toList()
+        val repository = RepositorySelector.select(project, changes) ?: run {
+            CleanerNotifications.warn(
+                "Currently you have no repository on this project. To get the branch name, you need to be on a repository."
+            )
             return
         }
         val branch = repository.currentBranch ?: run {
-            showNotification("Currently you are not on a branch. To get the branch name, you need to be on a branch.")
+            CleanerNotifications.warn(
+                "Currently you are not on a branch. To get the branch name, you need to be on a branch."
+            )
             return
         }
         val branchName = branch.name
 
-        val checkinPanel = event.getData(VcsDataKeys.COMMIT_MESSAGE_DOCUMENT) ?: return
-        val commitMessage = checkinPanel.text
+        val document = event.getData(VcsDataKeys.COMMIT_MESSAGE_DOCUMENT) ?: return
 
-        val cleanCommitMessage = CommitMessageCleaner.cleanWithTicketFromBranch(branchName, commitMessage)
-        WriteAction.runAndWait<Throwable> {
-            checkinPanel.setText(cleanCommitMessage)
-        }
+        val settings = CleanerSettingsState.current()
+        val cleanCommitMessage = CommitMessageCleaner.cleanWithTicketFromBranch(branchName, document.text, settings)
+        CommitMessageUpdater.apply(document, cleanCommitMessage, settings)
     }
 
     override fun getActionUpdateThread(): ActionUpdateThread {
         return ActionUpdateThread.EDT
-    }
-
-    private fun showNotification(content: String) {
-        Notifications.Bus.notify(
-            Notification(
-                "Commit Message Cleaner",
-                content,
-                NotificationType.WARNING
-            )
-        )
     }
 }

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/RepositorySelector.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/RepositorySelector.kt
@@ -1,0 +1,35 @@
+package com.hiosdra.commitmessagecleanerplugin
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.changes.Change
+import git4idea.repo.GitRepository
+import git4idea.repo.GitRepositoryManager
+
+/**
+ * Picks the Git repository whose branch should provide the ticket.
+ *
+ * In a single-repository project this is trivial, but in a monorepo / multi-module setup the first
+ * repository is not necessarily the one being committed to. When the set of changes is known, we
+ * resolve the repository from the files actually included in the commit, and only fall back to the
+ * first repository when nothing better can be determined.
+ */
+object RepositorySelector {
+
+    /**
+     * @param changes the changes included in the current commit, if available.
+     * @return the best matching repository, or `null` when the project has no Git repositories.
+     */
+    fun select(project: Project, changes: Collection<Change>?): GitRepository? {
+        val manager = GitRepositoryManager.getInstance(project)
+        val repositories = manager.repositories
+        if (repositories.size <= 1) return repositories.firstOrNull()
+
+        val fromChanges = changes
+            ?.asSequence()
+            ?.mapNotNull { change -> change.virtualFile ?: change.beforeRevision?.file?.virtualFile }
+            ?.mapNotNull { file -> manager.getRepositoryForFileQuick(file) }
+            ?.firstOrNull()
+
+        return fromChanges ?: repositories.first()
+    }
+}

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/settings/CleanerConfigurable.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/settings/CleanerConfigurable.kt
@@ -68,7 +68,7 @@ class CleanerConfigurable : Configurable {
                         .comment("Used only in the Conventional Commits style when no type is detected.")
                 }
             }
-            group("Ticket detection") {
+            group("Ticket Detection") {
                 row("Ticket regex:") {
                     textField()
                         .bindText(model::ticketRegex)

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/settings/CleanerConfigurable.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/settings/CleanerConfigurable.kt
@@ -1,0 +1,124 @@
+package com.hiosdra.commitmessagecleanerplugin.settings
+
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.SimpleListCellRenderer
+import com.intellij.ui.dsl.builder.bindItem
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.toNullableProperty
+import javax.swing.JComponent
+
+/**
+ * Settings panel under `Settings/Preferences | Tools | Commit Message Cleaner`.
+ *
+ * Lets the user tailor the plugin to their team's convention instead of the single hard-coded style,
+ * so it stays useful beyond Jira-style `PREFIX-123 | Message` commit messages.
+ */
+class CleanerConfigurable : Configurable {
+
+    /** Mutable mirror the UI binds to; seeded from and written back to the persistent state. */
+    private class Model(source: CleanerSettings) {
+        var separator = source.separator
+        var ticketRegex = source.ticketRegex
+        var capitalizeFirstLetter = source.capitalizeFirstLetter
+        var formatStyle = source.formatStyle
+        var conventionalDefaultType = source.conventionalDefaultType
+        var autoCleanOnCommit = source.autoCleanOnCommit
+        var showPreviewNotification = source.showPreviewNotification
+
+        fun toSettings() = CleanerSettings(
+            separator = separator,
+            ticketRegex = ticketRegex,
+            capitalizeFirstLetter = capitalizeFirstLetter,
+            formatStyle = formatStyle,
+            conventionalDefaultType = conventionalDefaultType,
+            autoCleanOnCommit = autoCleanOnCommit,
+            showPreviewNotification = showPreviewNotification,
+        )
+    }
+
+    private val model = Model(CleanerSettingsState.current())
+    private var dialogPanel: DialogPanel? = null
+
+    override fun getDisplayName(): String = "Commit Message Cleaner"
+
+    override fun createComponent(): JComponent {
+        val builtPanel = panel {
+            group("Format") {
+                row("Style:") {
+                    comboBox(
+                        FormatStyle.entries.toList(),
+                        SimpleListCellRenderer.create("") { style -> style?.let(::styleLabel) },
+                    ).bindItem(model::formatStyle.toNullableProperty())
+                }
+                row("Separator:") {
+                    textField()
+                        .bindText(model::separator)
+                        .comment("Placed between the ticket and the message, e.g. <code>ABC-123 | Message</code>.")
+                }
+                row {
+                    checkBox("Capitalize the first letter of the message")
+                        .bindSelected(model::capitalizeFirstLetter)
+                }
+                row("Default Conventional Commits type:") {
+                    textField()
+                        .bindText(model::conventionalDefaultType)
+                        .comment("Used only in the Conventional Commits style when no type is detected.")
+                }
+            }
+            group("Ticket detection") {
+                row("Ticket regex:") {
+                    textField()
+                        .bindText(model::ticketRegex)
+                        .comment("Regex that matches a ticket such as <code>ABC-123</code>.")
+                }
+            }
+            group("Behavior") {
+                row {
+                    checkBox("Clean the commit message automatically before committing")
+                        .bindSelected(model::autoCleanOnCommit)
+                }
+                row {
+                    checkBox("Show a before/after preview notification after cleaning")
+                        .bindSelected(model::showPreviewNotification)
+                }
+            }
+        }
+        dialogPanel = builtPanel
+        return builtPanel
+    }
+
+    override fun isModified(): Boolean {
+        val panel = dialogPanel ?: return false
+        panel.apply()
+        return model.toSettings() != CleanerSettingsState.current()
+    }
+
+    override fun apply() {
+        dialogPanel?.apply()
+        CleanerSettingsState.getInstance().fromSettings(model.toSettings())
+    }
+
+    override fun reset() {
+        val current = CleanerSettingsState.current()
+        model.separator = current.separator
+        model.ticketRegex = current.ticketRegex
+        model.capitalizeFirstLetter = current.capitalizeFirstLetter
+        model.formatStyle = current.formatStyle
+        model.conventionalDefaultType = current.conventionalDefaultType
+        model.autoCleanOnCommit = current.autoCleanOnCommit
+        model.showPreviewNotification = current.showPreviewNotification
+        dialogPanel?.reset()
+    }
+
+    override fun disposeUIResources() {
+        dialogPanel = null
+    }
+
+    private fun styleLabel(style: FormatStyle): String = when (style) {
+        FormatStyle.TICKET_PREFIX -> "Ticket prefix  (ABC-123 | Message)"
+        FormatStyle.CONVENTIONAL_COMMITS -> "Conventional Commits  (feat(ABC-123): message)"
+    }
+}

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/settings/CleanerSettings.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/settings/CleanerSettings.kt
@@ -1,0 +1,54 @@
+package com.hiosdra.commitmessagecleanerplugin.settings
+
+/**
+ * The output format the cleaner produces.
+ */
+enum class FormatStyle {
+    /** `TICKET-123 | Message` — the classic behavior of this plugin. */
+    TICKET_PREFIX,
+
+    /** `type(scope): description` — https://www.conventionalcommits.org */
+    CONVENTIONAL_COMMITS,
+}
+
+/**
+ * Immutable snapshot of the user's cleaning preferences.
+ *
+ * The [DEFAULT] value reproduces the plugin's original, hard-coded behavior exactly, so existing
+ * users see no change until they open the settings panel.
+ */
+data class CleanerSettings(
+    /** Separator placed between the ticket and the message in [FormatStyle.TICKET_PREFIX]. */
+    val separator: String = "|",
+
+    /** Regex (without anchors or groups) that recognizes a ticket such as `ABC-123`. */
+    val ticketRegex: String = "[A-Za-z]+-\\d+",
+
+    /** Capitalize the first letter of the normalized message. */
+    val capitalizeFirstLetter: Boolean = true,
+
+    /** Which output format to produce. */
+    val formatStyle: FormatStyle = FormatStyle.TICKET_PREFIX,
+
+    /** Default Conventional Commits type used when none can be detected in the message. */
+    val conventionalDefaultType: String = "feat",
+
+    /** Clean the commit message automatically right before a commit is created. */
+    val autoCleanOnCommit: Boolean = false,
+
+    /** Show a "before → after" balloon after a manual clean action. */
+    val showPreviewNotification: Boolean = false,
+) {
+    /** The compiled ticket matcher, anchored to the start of the text. */
+    val ticketPattern: Regex by lazy { Regex("^($ticketRegex)") }
+
+    companion object {
+        val DEFAULT = CleanerSettings()
+
+        /** Conventional Commits types recognized when parsing an existing message. */
+        val CONVENTIONAL_TYPES = listOf(
+            "feat", "fix", "chore", "docs", "style", "refactor",
+            "perf", "test", "build", "ci", "revert",
+        )
+    }
+}

--- a/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/settings/CleanerSettingsState.kt
+++ b/src/main/kotlin/com/hiosdra/commitmessagecleanerplugin/settings/CleanerSettingsState.kt
@@ -1,0 +1,70 @@
+package com.hiosdra.commitmessagecleanerplugin.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+/**
+ * Application-level, IDE-wide persistence for [CleanerSettings].
+ *
+ * Formatting style is a personal preference rather than a per-project one, so it lives at the
+ * application level and follows the user across every project.
+ */
+@Service(Service.Level.APP)
+@State(
+    name = "com.hiosdra.commitmessagecleanerplugin.CleanerSettings",
+    storages = [Storage("CommitMessageCleaner.xml")],
+)
+class CleanerSettingsState : PersistentStateComponent<CleanerSettingsState.State> {
+
+    /** Mutable, serializable mirror of [CleanerSettings]. */
+    class State {
+        var separator: String = CleanerSettings.DEFAULT.separator
+        var ticketRegex: String = CleanerSettings.DEFAULT.ticketRegex
+        var capitalizeFirstLetter: Boolean = CleanerSettings.DEFAULT.capitalizeFirstLetter
+        var formatStyle: FormatStyle = CleanerSettings.DEFAULT.formatStyle
+        var conventionalDefaultType: String = CleanerSettings.DEFAULT.conventionalDefaultType
+        var autoCleanOnCommit: Boolean = CleanerSettings.DEFAULT.autoCleanOnCommit
+        var showPreviewNotification: Boolean = CleanerSettings.DEFAULT.showPreviewNotification
+    }
+
+    private var state = State()
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = state
+    }
+
+    /** Read the current preferences as an immutable snapshot. */
+    fun toSettings(): CleanerSettings = CleanerSettings(
+        separator = state.separator,
+        ticketRegex = state.ticketRegex.ifBlank { CleanerSettings.DEFAULT.ticketRegex },
+        capitalizeFirstLetter = state.capitalizeFirstLetter,
+        formatStyle = state.formatStyle,
+        conventionalDefaultType = state.conventionalDefaultType.ifBlank { CleanerSettings.DEFAULT.conventionalDefaultType },
+        autoCleanOnCommit = state.autoCleanOnCommit,
+        showPreviewNotification = state.showPreviewNotification,
+    )
+
+    /** Overwrite the stored preferences from an immutable snapshot. */
+    fun fromSettings(settings: CleanerSettings) {
+        state.separator = settings.separator
+        state.ticketRegex = settings.ticketRegex
+        state.capitalizeFirstLetter = settings.capitalizeFirstLetter
+        state.formatStyle = settings.formatStyle
+        state.conventionalDefaultType = settings.conventionalDefaultType
+        state.autoCleanOnCommit = settings.autoCleanOnCommit
+        state.showPreviewNotification = settings.showPreviewNotification
+    }
+
+    companion object {
+        fun getInstance(): CleanerSettingsState =
+            ApplicationManager.getApplication().getService(CleanerSettingsState::class.java)
+
+        /** Convenience accessor for the current snapshot. */
+        fun current(): CleanerSettings = getInstance().toSettings()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,7 +17,8 @@
                 description="Clean commit message"
                 icon="/icons/clearCash/clearCash.svg">
             <add-to-group group-id="Vcs.MessageActionGroup" anchor="last"/>
-            <!--<keyboard-shortcut first-keystroke="ctrl -" keymap="$default"/>-->
+            <add-to-group group-id="Git.Menu" anchor="last"/>
+            <keyboard-shortcut first-keystroke="ctrl alt K" keymap="$default"/>
         </action>
         <action id="com.hiosdra.commitmessagecleanerplugin.GetFromBranchAndCleanAction"
                 class="com.hiosdra.commitmessagecleanerplugin.GetFromBranchAndCleanAction"
@@ -25,10 +26,19 @@
                 description="Get ticket branch name then clean"
                 icon="/icons/download/download.svg">
             <add-to-group group-id="Vcs.MessageActionGroup" anchor="last"/>
+            <add-to-group group-id="Git.Menu" anchor="last"/>
+            <keyboard-shortcut first-keystroke="ctrl alt shift K" keymap="$default"/>
         </action>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">
+        <applicationConfigurable
+                parentId="tools"
+                id="com.hiosdra.commitmessagecleanerplugin.settings.CleanerConfigurable"
+                instance="com.hiosdra.commitmessagecleanerplugin.settings.CleanerConfigurable"
+                displayName="Commit Message Cleaner"/>
+        <checkinHandlerFactory
+                implementation="com.hiosdra.commitmessagecleanerplugin.CleanOnCommitHandlerFactory"/>
         <notificationGroup
                 id="Commit Message Cleaner"
                 displayType="BALLOON"/>

--- a/src/test/kotlin/com/hiosdra/commitmessagecleanerplugin/CommitMessageCleanerSettingsTest.kt
+++ b/src/test/kotlin/com/hiosdra/commitmessagecleanerplugin/CommitMessageCleanerSettingsTest.kt
@@ -1,0 +1,92 @@
+package com.hiosdra.commitmessagecleanerplugin
+
+import com.hiosdra.commitmessagecleanerplugin.settings.CleanerSettings
+import com.hiosdra.commitmessagecleanerplugin.settings.FormatStyle
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+
+@RunWith(Enclosed::class)
+class CommitMessageCleanerSettingsTest {
+
+    class TicketPrefixConfigTest {
+        @Test
+        fun `should use a custom separator`() {
+            val settings = CleanerSettings(separator = ":")
+            val result = CommitMessageCleaner.cleanWithTicketNumber("ABC-123-implement-new-feature", settings)
+            assertEquals("ABC-123 : Implement new feature", result)
+        }
+
+        @Test
+        fun `should not capitalize when disabled`() {
+            val settings = CleanerSettings(capitalizeFirstLetter = false)
+            val result = CommitMessageCleaner.cleanWithTicketNumber("ABC-123-implement-new-feature", settings)
+            assertEquals("ABC-123 | implement new feature", result)
+        }
+
+        @Test
+        fun `should apply custom separator when taking ticket from branch`() {
+            val settings = CleanerSettings(separator = "::")
+            val result = CommitMessageCleaner.cleanWithTicketFromBranch(
+                "ABC-123-branch",
+                "DEF-456-implement-new-feature",
+                settings,
+            )
+            assertEquals("ABC-123 :: Implement new feature", result)
+        }
+    }
+
+    class ConventionalCommitsTest {
+        private val settings = CleanerSettings(formatStyle = FormatStyle.CONVENTIONAL_COMMITS)
+
+        @Test
+        fun `should format branch-style message with ticket as scope`() {
+            val result = CommitMessageCleaner.cleanWithTicketNumber("ABC-123-implement-new-feature", settings)
+            assertEquals("feat(ABC-123): implement new feature", result)
+        }
+
+        @Test
+        fun `should take scope from branch and detect the type`() {
+            val result = CommitMessageCleaner.cleanWithTicketFromBranch(
+                "ABC-123-login",
+                "fix login crash",
+                settings,
+            )
+            assertEquals("fix(ABC-123): login crash", result)
+        }
+
+        @Test
+        fun `should preserve an already conventional message`() {
+            val result = CommitMessageCleaner.cleanWithTicketFromBranch(
+                "ABC-123-x",
+                "feat(XYZ-1): add thing",
+                settings,
+            )
+            assertEquals("feat(XYZ-1): add thing", result)
+        }
+
+        @Test
+        fun `should backfill an empty scope from the branch ticket`() {
+            val result = CommitMessageCleaner.cleanWithTicketFromBranch(
+                "ABC-123-x",
+                "feat: add thing",
+                settings,
+            )
+            assertEquals("feat(ABC-123): add thing", result)
+        }
+
+        @Test
+        fun `should fall back to the default type without scope`() {
+            val result = CommitMessageCleaner.cleanWithTicketNumber("implement new feature", settings)
+            assertEquals("feat: implement new feature", result)
+        }
+
+        @Test
+        fun `should honor a custom default type`() {
+            val custom = settings.copy(conventionalDefaultType = "chore")
+            val result = CommitMessageCleaner.cleanWithTicketNumber("update deps", custom)
+            assertEquals("chore: update deps", result)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Turns the plugin from a single hard-coded style into a configurable one, and integrates it into the commit flow. The cleaner core was refactored to be driven by a `CleanerSettings` snapshot; **`CleanerSettings.DEFAULT` reproduces the previous behavior exactly**, so existing users see no change until they open the new settings panel.

This delivers the full **Tier 1 + Tier 2** feature set discussed with the maintainer.

### Tier 1
- **Settings panel** — `Settings/Preferences | Tools | Commit Message Cleaner`: separator, ticket regex, capitalization, format style, default Conventional type, and behavior toggles. Persisted IDE-wide via an application `@Service` (`CleanerSettingsState`).
  - *Outcome:* fits teams whose convention isn't Jira-style `PREFIX-123 | Message`, instead of being uninstalled after the first mismatch.
- **Conventional Commits** format style — `feat(ABC-123): message` with type detection, branch ticket as scope, empty-scope backfill, and pass-through of already-conventional messages.
  - *Outcome:* messages pass commitlint / semantic-release without manual fixups.
- **Clean on commit** — opt-in `CheckinHandler` that cleans the message right before the commit is created (default off).
  - *Outcome:* no more forgotten, uncleaned commits.

### Tier 2
- **Preview + atomic undo** — `CommitMessageUpdater` skips the write when nothing changes, keeps the whole-text replacement a single Undo step, and shows an optional before/after balloon.
- **Monorepo support** — `RepositorySelector` resolves the repository from the files included in the commit instead of always taking the first one.
- **Keyboard shortcuts + Git menu** — `Ctrl+Alt+K` (clean) / `Ctrl+Alt+Shift+K` (from branch), plus entries in the `Git` menu.

## Changes
- New: `settings/CleanerSettings`, `settings/CleanerSettingsState`, `settings/CleanerConfigurable`, `RepositorySelector`, `CommitMessageUpdater`, `CleanerNotifications`, `CleanOnCommitHandler(+Factory)`.
- Refactored: `CommitMessageCleaner` (config-driven + conventional mode), both actions, `plugin.xml`.
- Docs: README plugin description + CHANGELOG.

## Testing
- Added `CommitMessageCleanerSettingsTest` covering custom separator, disabled capitalization, and Conventional Commits scenarios.
- Existing 23 tests are unaffected (default behavior preserved).

> Note: a design decision worth confirming — the before/after **preview notification is default-off** to avoid noise; undo is atomic regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiwM45qqXMCnu8rDzzLUHc)_